### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Workspace Test
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/lilyanavalley/peace/security/code-scanning/5](https://github.com/lilyanavalley/peace/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow primarily involves testing and does not appear to require write access to the repository or other resources, we will set the permissions to `contents: read`. This ensures the workflow has the minimal permissions necessary to operate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
